### PR TITLE
Fixed Global State & Theme Toggle Context Bugs

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,24 +4,34 @@ import Link from 'next/link';
 import { ThemeToggle } from './ThemeToggle';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import { useEffect, useState } from 'react';
 
 export const Navbar: React.FC = () => {
   const { isAuthenticated, setIsAuthenticated, userProfile, setUserProfile } = useAuth();
   const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem('token');
     setIsAuthenticated(false);
-    setUserProfile(null)
+    setUserProfile(null);
     router.push('/login');
   };
 
   const NavLink: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => {
-    if (!isAuthenticated && href !== '/' && href !== '/login') {
-      href = '/login';
+    if (!mounted) {
+      return <span className="py-4 px-2 text-gray-600 dark:text-gray-100">{children}</span>;
     }
+
     return (
-      <Link href={href} className="py-4 px-2 text-gray-600 dark:text-gray-100 hover:text-green-500 transition duration-300">
+      <Link 
+        href={!isAuthenticated && href !== '/' && href !== '/login' ? '/login' : href}
+        className="py-4 px-2 text-gray-600 dark:text-gray-100 hover:text-green-500 transition duration-300"
+      >
         {children}
       </Link>
     );
@@ -50,7 +60,10 @@ export const Navbar: React.FC = () => {
                 <span className="text-gray-500 dark:text-gray-100">
                   {userProfile?.username}
                 </span>
-                <button onClick={handleLogout} className="py-4 px-2 text-gray-500 dark:text-gray-100 hover:text-green-500 transition duration-300">
+                <button 
+                  onClick={handleLogout} 
+                  className="py-4 px-2 text-gray-500 dark:text-gray-100 hover:text-green-500 transition duration-300"
+                >
                   Logout
                 </button>
               </>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTheme } from '../context/ThemeContext';
 
 export const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <button
       onClick={toggleTheme}
       className="p-2 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
     >
-      {theme === 'light' ? '🌙' : '☀️'}
+      {mounted ? (theme === 'light' ? '🌙' : '☀️') : null}
     </button>
   );
 };

--- a/src/components/forms/Login.tsx
+++ b/src/components/forms/Login.tsx
@@ -1,44 +1,42 @@
 "use client"
 
-import { useAuth } from '@/context/AuthContext'
-import { login } from '@/services/auth'
-import { LoginCredentials } from '@/types/auth.types'
-import { useRouter } from 'next/navigation'
-import { useState } from "react"
+import { useAuth } from '@/context/AuthContext';
+import { login } from '@/services/auth';
+import { LoginCredentials } from '@/types/auth.types';
+import { useRouter } from 'next/navigation';
+import { useState } from "react";
 
 const LoginForm = () => {
-    const [username, setUsername] = useState("")
-    const [password, setPassword] = useState("")
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
-    const { setIsAuthenticated, setUserProfile } = useAuth();
-    const router = useRouter()
+    const { setAuthData } = useAuth();
+    const router = useRouter();
 
     const togglePasswordVisibility = () => {
         setShowPassword(!showPassword);
     };
     
     const submit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
+        e.preventDefault();
 
         const loginRequest: LoginCredentials = {
             username: username,
             password: password
-        }
+        };
 
         try {
             const authData = await login(loginRequest);
-            if (authData) {
-                setIsAuthenticated(true);
-                setUserProfile(authData.user);
-                router.push('/')
+            if (authData?.token && authData.user) {
+                setAuthData(authData.token, authData.user);
+                router.push('/');
             } else {
-                window.alert("Please use valid username & password")
+                window.alert("Please use valid username & password");
             }
         } catch (error) {
-            console.error('login failed:', error)
+            console.error('login failed:', error);
         }
-
-    }
+    };
 
     return (
         <div className="container mx-auto mt-10 max-w-md">
@@ -56,23 +54,23 @@ const LoginForm = () => {
                 </div>
                 <div>
                     <div className="relative">
-                    <label htmlFor="password" className="block mb-1">Password</label>
-                    <input 
-                        type={showPassword ? "text" : "password"}
-                        id="password" 
-                        name="password" 
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        className="w-full border rounded p-2 pr-10 dark:text-gray-800" 
-                    />
-                    <button
-                        type="button"
-                        onClick={togglePasswordVisibility}
-                        className="absolute inset-y-0 right-0 top-6 pr-3 flex items-center text-gray-600 hover:text-gray-800"
-                    >
-                        {showPassword ? "🫣" : "👀"}
-                    </button>
-                </div>
+                        <label htmlFor="password" className="block mb-1">Password</label>
+                        <input 
+                            type={showPassword ? "text" : "password"}
+                            id="password" 
+                            name="password" 
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            className="w-full border rounded p-2 pr-10 dark:text-gray-800" 
+                        />
+                        <button
+                            type="button"
+                            onClick={togglePasswordVisibility}
+                            className="absolute inset-y-0 right-0 top-6 pr-3 flex items-center text-gray-600 hover:text-gray-800"
+                        >
+                            {showPassword ? "🫣" : "👀"}
+                        </button>
+                    </div>
                 </div>
                 <div className="text-center">
                     <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
@@ -85,14 +83,14 @@ const LoginForm = () => {
             <br />
             <div className="flex justify-center mx-auto max-w-md">
                 <button 
-                className="bg-gray-500 text-white px-4 py-2 rounded"
-                onClick={()=>{router.push("/register")}}
+                    className="bg-gray-500 text-white px-4 py-2 rounded"
+                    onClick={() => router.push("/register")}
                 >
                     Don't have an account?
                 </button>
             </div>
         </div>
-    )
-}
+    );
+};
 
-export default LoginForm
+export default LoginForm;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import React, { createContext, useState, useContext } from 'react';
 import { UserProfile } from '@/types/user.types';
+import React, { createContext, useState, useContext, useEffect } from 'react';
+
 
 type AuthContextType = {
   isAuthenticated: boolean;
   userProfile: UserProfile | null;
   setIsAuthenticated: (value: boolean) => void;
   setUserProfile: (profile: UserProfile | null) => void;
+  setAuthData: (token: string, user: UserProfile) => void;
+  isLoading: boolean;
 };
 
 const AuthContext = createContext<AuthContextType>({
@@ -15,18 +18,56 @@ const AuthContext = createContext<AuthContextType>({
   userProfile: null,
   setIsAuthenticated: () => {},
   setUserProfile: () => {},
+  setAuthData: () => {},
+  isLoading: true,
 });
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
 
+  // Initialize auth state
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      const storedProfile = localStorage.getItem('userProfile');
+      
+      setIsAuthenticated(!!token);
+      setUserProfile(storedProfile ? JSON.parse(storedProfile) : null);
+      setIsLoading(false);
+    }
+  }, []);
+
+  const setAuthData = (token: string, user: UserProfile) => {
+    localStorage.setItem('token', token);
+    localStorage.setItem('userProfile', JSON.stringify(user));
+    setIsAuthenticated(true);
+    setUserProfile(user);
+  };
+
+  // Watch for token removal
+  useEffect(() => {
+    const handleStorageChange = () => {
+      const token = localStorage.getItem('token');
+      if (!token) {
+        setIsAuthenticated(false);
+        setUserProfile(null);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ 
-      isAuthenticated, 
-      userProfile, 
-      setIsAuthenticated, 
-      setUserProfile 
+    <AuthContext.Provider value={{
+      isAuthenticated,
+      userProfile,
+      setIsAuthenticated,
+      setUserProfile,
+      setAuthData,
+      isLoading,
     }}>
       {children}
     </AuthContext.Provider>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,4 +1,4 @@
-'use client'; 
+'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
@@ -12,24 +12,23 @@ type ThemeContextType = {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>('light');
-
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as Theme | null;
-    if (savedTheme) {
-      setTheme(savedTheme);
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setTheme('dark');
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme) return savedTheme as Theme;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
-  }, []);
+    return 'light';
+  });
 
   useEffect(() => {
-    localStorage.setItem('theme', theme);
+    const root = document.documentElement.classList;
     if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
+      root.add('dark');
     } else {
-      document.documentElement.classList.remove('dark');
+      root.remove('dark');
     }
+    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const toggleTheme = () => {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,6 @@
 import { AuthResponse, LoginCredentials, RegisterData } from "@/types/auth.types";
 import { fetchWithResponse } from "./fetcher";
 
-
 export const login = async (credentials: LoginCredentials): Promise<AuthResponse | null> => {
   const response = await fetchWithResponse<AuthResponse>('login', {
     method: 'POST',


### PR DESCRIPTION
# Description

Fixed login and dark mode settings being lost when refreshing the page. Now when users log in or change their theme, their preferences stay even after refreshing. This works by saving important information in the browser's localStorage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [x] Test Login Persistence:
  1. Log in to the application
  2. Refresh the page
  3. Verify you're still logged in
  4. Check that you can still access protected pages (Explore & Impact)

- [x] Test Theme Persistence:
  1. Switch between light and dark mode
  2. Refresh the page
  3. Verify the theme stays the same as what you selected

- [x] Test Logout:
  1. Log in to the application
  2. Click logout
  3. Verify you're redirected to login page
  4. Refresh the page
  5. Verify you stay logged out

Main changes:
- Added localStorage to save user login state
- Added localStorage to save theme preference
- Fixed hydration errors in ThemeToggle component
- Cleaned up navbar code