### PR TITLE
Delete impact plan functionality working as expected

### DIFF
--- a/src/app/impactplans/[id]/page.tsx
+++ b/src/app/impactplans/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
-import { createImpactPlan, getAllImpactPlans, updateImpactPlan } from "@/services/impactPlan";
+import { createImpactPlan, deleteImpactPlan, getAllImpactPlans, updateImpactPlan } from "@/services/impactPlan";
 import { ImpactPlan } from "@/types/impactPlan.types";
 import { formatCurrency } from '@/utils/impactMetrics';
 import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from "@nextui-org/react";
@@ -130,8 +130,6 @@ const ImpactPlanSettings = () => {
   
       const response = await updateImpactPlan(impactPlan.id, requestBody);
       setImpactPlan(response.data);
-      
-      console.log('Updating plan:', requestBody);
     } catch (error) {
       console.error('Error updating impact plan:', error);
     }
@@ -140,8 +138,7 @@ const ImpactPlanSettings = () => {
   const handleDeletePlan = async () => {
     try {
       if (impactPlan?.id) {
-        // TODO: Add API call to delete plan
-        console.log('Deleting plan:', impactPlan.id);
+        deleteImpactPlan(impactPlan.id)
         setDeleteModalOpen(false);
         // After successful delete, reset to new plan state
         setIsNewPlan(true);

--- a/src/services/impactPlan.ts
+++ b/src/services/impactPlan.ts
@@ -1,5 +1,5 @@
 import { ImpactPlan } from "@/types/impactPlan.types"
-import { fetchWithResponse } from "./fetcher"
+import { fetchWithoutResponse, fetchWithResponse } from "./fetcher"
 
 export const getImpactPlanById = async (planId: number) => {
   return await fetchWithResponse<ImpactPlan>(`impactplans/${planId}`, {
@@ -38,5 +38,15 @@ export const updateImpactPlan = async (planId: number, plan: any) => {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(plan)
+  });
+}
+
+export const deleteImpactPlan = async (planId: number) => {
+  return await fetchWithoutResponse(`impactplans/${planId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`,
+      'Content-Type': 'application/json'
+    }
   });
 }


### PR DESCRIPTION
# Description

1. Added the service function of `deleteImpactPlan` & called it within the `page.tsx` under `impactplans/[id]` to remove the current Impact Plan and reset the values to default. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1 - Log in with a user that has an active impact plan or create a new one
- [ ] Step 2 - Delete the plan in Impact Plan Settings & Confirm in the modal
- [ ] Step 3 - Verify that the plan is now reset to 0, and it is absent in the database. 
