### PR TITLE
updated charity details and next.config to allow for image rendering

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;
+const nextConfig = {
+    images: {
+      remotePatterns: [
+        {
+          protocol: 'http',
+          hostname: 'localhost',
+          port: '8000',
+          pathname: '/media/**',
+        },
+      ],
+    },
+  };
+  
+  export default nextConfig;

--- a/src/components/charities/CharityDetails.tsx
+++ b/src/components/charities/CharityDetails.tsx
@@ -11,6 +11,7 @@ import { getAllImpactPlans } from '@/services/impactPlan';
 import { ImpactPlan } from '@/types/impactPlan.types';
 import { createImpactPlanCharity } from '@/services/impactPlanCharity';
 import { useRouter } from 'next/navigation';
+import { baseUrl } from '@/services/fetcher';
 
 const CharityDetails = () => {
   const { userProfile } = useAuth();
@@ -175,7 +176,7 @@ const CharityDetails = () => {
                 {charity?.image ? (
                 <div className="relative w-full h-full">
                     <Image
-                    src={charity?.image}
+                    src={`${baseUrl}${charity.image}`}
                     alt={`${charity.name} image`}
                     fill
                     className="object-cover"
@@ -183,7 +184,7 @@ const CharityDetails = () => {
                 </div>
                 ) : (
                 <div className="w-full h-full flex items-center justify-center bg-gray-50 dark:bg-gray-700">
-                    <span className="text-gray-400 dark:text-gray-500">Image Card</span>
+                    <span className="text-gray-400 dark:text-gray-500">Upload Image</span>
                 </div>
                 )}
             </div>

--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -1,6 +1,6 @@
 import { ApiError, ApiResponse } from "@/types/auth.types";
 
-const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+export const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
 const checkError = (response: Response): Response => {
   if (!response.ok) {


### PR DESCRIPTION
# Description

Images were not being rendered to the DOM due to a pre-pend that was absent from the logic in `CharityDetails` & the need for image transfer in `next.config.mjs`

1. Exported the `baseUrl` from `fetcher`
2. Imported `baseUrl` and pre-pended to the front of `charity.image` for proper rendering to the DOM
3. `next.config.mjs` updated to allow image transfer from the `baseUrl`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
