### PR TITLE
Error & Success Banners Replace Window Alerts

### DIFF
--- a/src/components/charities/CharityDetails.tsx
+++ b/src/components/charities/CharityDetails.tsx
@@ -19,6 +19,7 @@ const CharityDetails = () => {
   const [charity, setCharity] = useState<Charity | undefined>(undefined);
   const [impactPlan, setImpactPlan] = useState<ImpactPlan | null>(null);
   const [error, setError] = useState<string | null>(null); 
+  const [success, setSuccess] = useState<string | null>(null);
   const router = useRouter()
  
   useEffect(() => {
@@ -71,6 +72,10 @@ const CharityDetails = () => {
   }
 
   const handleAddToImpact = async () => {
+      setError(null);
+    setSuccess(null);
+
+
     if (!impactPlan) {
       setError("Please create an Impact Plan first to add charities.");
       return;
@@ -97,7 +102,7 @@ const CharityDetails = () => {
         charity_id: charity.id,
         allocation_amount: 0 // Default to 0, to be updated later
       });
-      window.alert('Charity Added to Your Impact Plan!');
+      setSuccess('Charity successfully added to your Impact Plan!');
     } catch (error: any) {
       setError("Failed to add charity to impact plan");
     }
@@ -109,6 +114,11 @@ const CharityDetails = () => {
         {error && (
           <div className="mb-6 p-4 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100 rounded-lg">
             {error}
+          </div>
+        )}
+        {success && (
+          <div className="mb-6 p-4 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 rounded-lg">
+            {success}
           </div>
         )}
         <div className="space-y-6">

--- a/src/components/impact/ImpactPlanSettings.tsx
+++ b/src/components/impact/ImpactPlanSettings.tsx
@@ -17,6 +17,7 @@ const ImpactPlanSettings = () => {
     philanthropyPercentage,
     isLoading,
     isNewPlan,
+    message,
     handleAnnualIncomeChange,
     handlePercentageChange,
     handleSavePlan,
@@ -43,6 +44,15 @@ const ImpactPlanSettings = () => {
 
   return (
     <div className="container mx-auto p-6">
+      {message && (
+        <div className={`mb-6 p-4 rounded-lg ${
+          message.type === 'success' 
+            ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100' 
+            : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-100'
+        }`}>
+          {message.text}
+        </div>
+      )}
       <div className="flex gap-6">
         {/* Left Column - Settings */}
         <div className="w-1/3 space-y-4">

--- a/src/hooks/useImpactPlanManager.tsx
+++ b/src/hooks/useImpactPlanManager.tsx
@@ -12,6 +12,12 @@ import {
 } from "@/services/impactPlanCharity";
 import { ImpactPlan, ImpactPlanCharity } from "@/types/impactPlan.types";
 
+type Message = {
+  type: 'success' | 'error';
+  text: string;
+} | null;
+
+
 export const useImpactPlanManager = () => {
   const { userProfile } = useAuth();
   const [impactPlan, setImpactPlan] = useState<ImpactPlan | null>(null);
@@ -19,6 +25,7 @@ export const useImpactPlanManager = () => {
   const [philanthropyPercentage, setPhilanthropyPercentage] = useState<string>("");
   const [isLoading, setIsLoading] = useState(true);
   const [isNewPlan, setIsNewPlan] = useState(false);
+  const [message, setMessage] = useState<Message>(null);
 
   useEffect(() => {
     fetchImpactPlan();
@@ -121,8 +128,11 @@ export const useImpactPlanManager = () => {
       const response = await createImpactPlan(requestBody);
       setImpactPlan(response.data);
       setIsNewPlan(false);
+      setMessage({ type: 'success', text: 'Impact Plan created successfully!' });
+      setTimeout(() => setMessage(null), 5000);
     } catch (error) {
       console.error('Error creating impact plan:', error);
+      setMessage({ type: 'error', text: 'Failed to create Impact Plan. Please try again.' });
     }
   };
 
@@ -139,8 +149,11 @@ export const useImpactPlanManager = () => {
 
       const response = await updateImpactPlan(impactPlan.id, requestBody);
       setImpactPlan(response.data);
+      setMessage({ type: 'success', text: 'Impact Plan created successfully!' });
+      setTimeout(() => setMessage(null), 5000);
     } catch (error) {
       console.error('Error updating impact plan:', error);
+      setMessage({ type: 'error', text: 'Failed to create Impact Plan. Please try again.' });
     }
   };
 
@@ -153,9 +166,12 @@ export const useImpactPlanManager = () => {
         setImpactPlan(null);
         setAnnualIncome("");
         setPhilanthropyPercentage("");
+        setMessage({ type: 'success', text: 'Impact Plan deleted successfully!' });
+        setTimeout(() => setMessage(null), 5000);
       }
     } catch (error) {
       console.error('Error deleting impact plan:', error);
+      setMessage({ type: 'error', text: 'Failed to delete Impact Plan. Please try again.' });
     }
   };
 
@@ -183,6 +199,7 @@ export const useImpactPlanManager = () => {
     philanthropyPercentage,
     isLoading,
     isNewPlan,
+    message,
     handleAnnualIncomeChange,
     handlePercentageChange,
     handleSavePlan,


### PR DESCRIPTION
# Description

After a small sample of beta testing, I noticed that window alerts were a bit too aggressive for the error & success alerts. 

Made alterations to:
1. `useImpactPlanManager` custom hook
2. `CharityDetails` view
3. `ImpactPlanSettings` view


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
