### PR TITLE
Ft/error banner redirect

### DIFF
--- a/src/components/charities/CharityDetails.tsx
+++ b/src/components/charities/CharityDetails.tsx
@@ -18,7 +18,7 @@ const CharityDetails = () => {
   const { id } = useParams<{ id: string }>();
   const [charity, setCharity] = useState<Charity | undefined>(undefined);
   const [impactPlan, setImpactPlan] = useState<ImpactPlan | null>(null);
-  const [error, setError] = useState<string | null>(null); 
+  const [error, setError] = useState<string | React.ReactNode | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const router = useRouter()
  
@@ -77,7 +77,16 @@ const CharityDetails = () => {
 
 
     if (!impactPlan) {
-      setError("Please create an Impact Plan first to add charities.");
+      setError(
+        <>
+          Please create an Impact Plan first to add charities. You can{' '}
+          <Link 
+          href="/impactplans/undefined"
+          className='text-blue-500 dark:text-blue-400'>
+            CLICK HERE
+            </Link> to go directly to yours!
+        </>
+      );
       return;
     }
 

--- a/src/hooks/useImpactPlanManager.tsx
+++ b/src/hooks/useImpactPlanManager.tsx
@@ -128,7 +128,7 @@ export const useImpactPlanManager = () => {
       const response = await createImpactPlan(requestBody);
       setImpactPlan(response.data);
       setIsNewPlan(false);
-      setMessage({ type: 'success', text: 'Impact Plan created successfully!' });
+      setMessage({ type: 'success', text: 'Impact Plan updated successfully!' });
       setTimeout(() => setMessage(null), 5000);
     } catch (error) {
       console.error('Error creating impact plan:', error);


### PR DESCRIPTION
# Description

With the feedback from Demo day, I wanted to make a redirect link from the error banner in the charity details cards that would redirect to the impact plan settings for a user that has no pre-existing impact plan. The changes for this PR include:

1. Error banner for `Charity Details` to redirect to `/impactplans/undefined`
2. Success banner for `useImpactPlanManager` custom hook to change from `created` to `updated` for use in both `create` & `update` methods

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
