### PR TITLE
Demo Day Feedback & Tweaks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,12 @@ const nextConfig = {
         port: '',
         pathname: '/media/**',
       },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '8000',
+        pathname: '/media/**',
+      },
     ],
   },
   eslint: {

--- a/src/components/forms/charities/CharityCreate.tsx
+++ b/src/components/forms/charities/CharityCreate.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { CharityCategory } from "@/types/charityCategory";
 import { getCharityCategories } from '@/services/charityCategory';
 import { createCharity } from '@/services/charity';
+import { Tooltip } from '@nextui-org/react';
+import { IconInfoCircle } from '@tabler/icons-react';
 
 export interface CharityFormData {
   name: string;
@@ -148,6 +150,9 @@ const CharityForm = () => {
         <div>
           <label htmlFor="impact_metric" className="labelClasses">
             Impact Metric
+            <Tooltip content="Describe what donation wills go towards (e.g., 'meals provided', 'trees planted', etc). Keep it concise and measurable.">
+            <span className="text-sm text-gray-500 cursor-help"><IconInfoCircle/></span>
+            </Tooltip>
           </label>
           <input
             type="text"
@@ -163,6 +168,9 @@ const CharityForm = () => {
         <div>
           <label htmlFor="impact_ratio" className="labelClasses">
             Impact Ratio
+            <Tooltip content="Enter how many people can be helped per $1. Example: If $20 provides water for 1 person, then 1÷20 = 0.05 people helped per $1. Enter 0.05 as your impact ratio.">
+            <span className="text-sm text-gray-500 cursor-help"><IconInfoCircle/></span>
+            </Tooltip>
           </label>
           <input
             type="number"

--- a/src/components/forms/charities/CharityEdit.tsx
+++ b/src/components/forms/charities/CharityEdit.tsx
@@ -6,6 +6,7 @@ import { CharityCategory } from "@/types/charityCategory";
 import { getCharityCategories } from '@/services/charityCategory';
 import { getCharityById, updateCharity } from '@/services/charity';
 import { CharityFormData } from './CharityCreate';
+import { baseUrl } from '@/services/fetcher';
 
 interface Props {
   charityId: number;
@@ -210,7 +211,7 @@ const CharityEditForm = ({ charityId }: Props) => {
           {formData.image && (
             <div className="mt-2">
               <img 
-                src={formData.image} 
+                src={`${baseUrl}${formData.image}`} 
                 alt="Current charity image" 
                 className="max-w-xs h-auto"
               />


### PR DESCRIPTION
# Description

With the feedback from Demo day, I wanted to make a redirect link from the error banner in the charity details cards that would redirect to the impact plan settings for a user that has no pre-existing impact plan. The changes for this PR include:

1. Error banner for `Charity Details` to redirect to `/impactplans/undefined`
2. Success banner for `useImpactPlanManager` custom hook to change from `created` to `updated` for use in both `create` & `update` methods

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Chore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
