### PR TITLE
Added Dockerfile for GCP deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# Install dependencies exactly from lockfile
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build Next.js app (disable Turbopack for reliability in Docker)
+RUN npm run build --no-turbo
+
+# Stage 2: Production image
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+# Install production dependencies only
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy build artifacts from builder
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
+
+# Expose Cloud Run default port
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+# Run the Next.js server
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
This pull request introduces a new multi-stage `Dockerfile` to optimize the build and deployment process for the Next.js application. The Dockerfile separates the build and production environments, ensuring only production dependencies and build artifacts are included in the final image.

**Dockerfile improvements:**

* Added a multi-stage build process to separate dependency installation, build, and production runtime, resulting in smaller and more secure images.
* Ensured only production dependencies are installed in the final image by using `npm ci --omit=dev`.
* Copied only the necessary build artifacts (`.next`, `public`, and `next.config.mjs`) from the builder stage to the production image, reducing the final image size.
* Set environment variables and exposed port 8080 for compatibility with Cloud Run deployments.
* Disabled Turbopack during the build for reliability in Docker environments.