### PR TITLE
updated service request api endpoint for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -1,6 +1,6 @@
 import { ApiError, ApiResponse } from "@/types/auth.types";
 
-export const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+export const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
 const checkError = (response: Response): Response => {
   if (!response.ok) {


### PR DESCRIPTION
This pull request makes a minor update to the `src/services/fetcher.ts` file. The change removes the default fallback value for the `baseUrl` constant, so it now strictly uses the `NEXT_PUBLIC_API_URL` environment variable.

* Updated `baseUrl` to remove the `'http://localhost:8000'` fallback, ensuring only the environment variable is used.