### PR TITLE
Adding production .env variable for api url to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:20-slim AS builder
 
 WORKDIR /app
 
+# Accept NEXT_PUBLIC_API_URL at build time
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
 # Install dependencies exactly from lockfile
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
This pull request makes a small change to the `Dockerfile` to allow the `NEXT_PUBLIC_API_URL` environment variable to be set at build time. This enables more flexible configuration of the application during the build process.